### PR TITLE
Fix qwen3 eagle

### DIFF
--- a/torchtune/models/qwen3/_convert_weights.py
+++ b/torchtune/models/qwen3/_convert_weights.py
@@ -85,6 +85,8 @@ def qwen3_hf_to_tune(
         converted_state_dict[new_key] = value
     return converted_state_dict
 
+DECODER_PREFIX = "decoder."
+DECODER_PREFIX_LENGTH = len(DECODER_PREFIX)
 
 def qwen3_tune_to_hf(
     state_dict: dict[str, torch.Tensor],
@@ -117,7 +119,12 @@ def qwen3_tune_to_hf(
         head_dim = dim // num_heads
 
     for key, value in state_dict.items():
-        new_key = get_mapped_key(key, inverted_mapping_dict)
+        if key.startswith(DECODER_PREFIX):
+            key = key[DECODER_PREFIX_LENGTH:] # hack for qwen3 eagle, as we use an EarlyFusionModel instead of a TransformerDecoder
+        if key.startswith("draft"):
+            new_key = key
+        else:
+            new_key = get_mapped_key(key, inverted_mapping_dict)
         converted_state_dict[new_key] = value
         if QWEN3_TUNE_EMBEDDING_KEY in key and tie_word_embeddings:
             # If the model's input and output word embeddings are tied, we need to

--- a/torchtune/modules/transformer.py
+++ b/torchtune/modules/transformer.py
@@ -252,7 +252,10 @@ class TransformerDraftAttentionLayer(nn.Module):
         # [b, s, d]
         # Norm applied before self-attention
         
-        residual = x[..., 5120:]
+        # Extract residual as the second half of input features
+        # Input is concatenated [input_embeds, fused_features] so residual is fused_features
+        embed_dim = x.shape[-1] // 2
+        residual = x[..., embed_dim:]
         
         h = self.sa_norm(x)
         if self.mask_mod is not None:


### PR DESCRIPTION
#### Context
What is the purpose of this PR? Is it to
- [ ] add a new feature
- [x] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

Please link to any issues this PR addresses.

Working with @sleepcoo on qwen3

#### Changelog
What are the changes made in this PR?
*

#### Test plan
Please make sure to do each of the following if applicable to your PR. If you're unsure about any one of these just ask and we will happily help. We also have a [contributing page](https://github.com/pytorch/torchtune/blob/main/CONTRIBUTING.md) for some guidance on contributing.

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add [unit tests](https://github.com/pytorch/torchtune/tree/main/tests/torchtune) for any new functionality
- [ ] update [docstrings](https://github.com/pytorch/torchtune/tree/main/docs/source) for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)

#### UX
If your function changed a public API, please add a dummy example of what the user experience will look like when calling it.
Here is a [docstring example](https://github.com/pytorch/torchtune/blob/6a7951f1cdd0b56a9746ef5935106989415f50e3/torchtune/modules/vision_transformer.py#L285)
and a [tutorial example](https://pytorch.org/torchtune/main/tutorials/qat_finetune.html#applying-qat-to-llama3-models)

- [x] I did not change any public API
- [ ] I have added an example to docs or docstrings
